### PR TITLE
build archlinux package as user 'build'

### DIFF
--- a/archlinux/build.sh
+++ b/archlinux/build.sh
@@ -14,4 +14,4 @@ cp $ARCHIVE_BASE/PKGBUILD .
 SHASUM=`sha512sum $ARCHIVE | awk '{print $1;}'`
 sed "s/%SHA512SUM%/$SHASUM/g" -i PKGBUILD
 
-makepkg
+sudo -u build makepkg


### PR DESCRIPTION
Command 'makepkg' may not be executed as root.